### PR TITLE
Update app to include time segments and summary range views

### DIFF
--- a/ToDoList.xcodeproj/project.pbxproj
+++ b/ToDoList.xcodeproj/project.pbxproj
@@ -28,8 +28,23 @@
 		5E3AC3652BB91AB2001C8876 /* ToDoListViewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E3AC3642BB91AB2001C8876 /* ToDoListViewViewModel.swift */; };
 		5E3AC3672BB91CB3001C8876 /* HeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E3AC3662BB91CB3001C8876 /* HeaderView.swift */; };
 		5E3AC3692BB9239F001C8876 /* TLButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E3AC3682BB9239F001C8876 /* TLButton.swift */; };
+		5E6E24492CD9DCB60075AEC3 /* TimeSegment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E6E24482CD9DCB60075AEC3 /* TimeSegment.swift */; };
+		5E6E244B2CD9F2AE0075AEC3 /* TimeSegmentListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E6E244A2CD9F2AE0075AEC3 /* TimeSegmentListView.swift */; };
+		5E6E244E2CD9F66D0075AEC3 /* TimeFormatUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E6E244D2CD9F66D0075AEC3 /* TimeFormatUtils.swift */; };
+		5E6E24502CDB410F0075AEC3 /* SummaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E6E244F2CDB410F0075AEC3 /* SummaryView.swift */; };
+		5E6E24522CDB41BD0075AEC3 /* SummaryRangeViewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E6E24512CDB41BD0075AEC3 /* SummaryRangeViewViewModel.swift */; };
+		5E6E24552CDB426E0075AEC3 /* SummaryRangeEnum.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E6E24542CDB426E0075AEC3 /* SummaryRangeEnum.swift */; };
+		5E6E24572CDB4EBD0075AEC3 /* SummaryRangeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E6E24562CDB4EBD0075AEC3 /* SummaryRangeView.swift */; };
+		5E6E24592CDB51B00075AEC3 /* TaskSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E6E24582CDB51B00075AEC3 /* TaskSummary.swift */; };
 		5E82EEEE2C68391C00548EC5 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E82EEED2C68391C00548EC5 /* Extensions.swift */; };
 		5EA5C1342CC5FF2700CCE426 /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 5EA5C1332CC5FF2700CCE426 /* Launch Screen.storyboard */; };
+		5EAEC5D02CCDAD7A00BB11F8 /* TimerTaskListViewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EAEC5CF2CCDAD7A00BB11F8 /* TimerTaskListViewViewModel.swift */; };
+		5EAEC5D22CCDAD8D00BB11F8 /* TaskTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EAEC5D12CCDAD8D00BB11F8 /* TaskTimer.swift */; };
+		5EAEC5D62CCDADB600BB11F8 /* TaskTimerListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EAEC5D52CCDADB600BB11F8 /* TaskTimerListView.swift */; };
+		5EAEC5D82CCDAE9F00BB11F8 /* TaskTimerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EAEC5D72CCDAE9F00BB11F8 /* TaskTimerView.swift */; };
+		5EAEC5DA2CCDAED900BB11F8 /* TaskTimerViewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EAEC5D92CCDAED900BB11F8 /* TaskTimerViewViewModel.swift */; };
+		5EAEC5DC2CCDB6D200BB11F8 /* NewTaskItemViewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EAEC5DB2CCDB6D200BB11F8 /* NewTaskItemViewViewModel.swift */; };
+		5EAEC5DE2CCDB7A100BB11F8 /* NewTaskItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EAEC5DD2CCDB7A100BB11F8 /* NewTaskItemView.swift */; };
 		5ED670212BB918CB0061210C /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ED670202BB918CB0061210C /* MainView.swift */; };
 		5EDC5C202BB8DD7800363517 /* ToDoListApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EDC5C1F2BB8DD7800363517 /* ToDoListApp.swift */; };
 		5EDC5C242BB8DD7900363517 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5EDC5C232BB8DD7900363517 /* Assets.xcassets */; };
@@ -75,8 +90,23 @@
 		5E3AC3642BB91AB2001C8876 /* ToDoListViewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToDoListViewViewModel.swift; sourceTree = "<group>"; };
 		5E3AC3662BB91CB3001C8876 /* HeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderView.swift; sourceTree = "<group>"; };
 		5E3AC3682BB9239F001C8876 /* TLButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TLButton.swift; sourceTree = "<group>"; };
+		5E6E24482CD9DCB60075AEC3 /* TimeSegment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeSegment.swift; sourceTree = "<group>"; };
+		5E6E244A2CD9F2AE0075AEC3 /* TimeSegmentListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeSegmentListView.swift; sourceTree = "<group>"; };
+		5E6E244D2CD9F66D0075AEC3 /* TimeFormatUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeFormatUtils.swift; sourceTree = "<group>"; };
+		5E6E244F2CDB410F0075AEC3 /* SummaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryView.swift; sourceTree = "<group>"; };
+		5E6E24512CDB41BD0075AEC3 /* SummaryRangeViewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryRangeViewViewModel.swift; sourceTree = "<group>"; };
+		5E6E24542CDB426E0075AEC3 /* SummaryRangeEnum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryRangeEnum.swift; sourceTree = "<group>"; };
+		5E6E24562CDB4EBD0075AEC3 /* SummaryRangeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryRangeView.swift; sourceTree = "<group>"; };
+		5E6E24582CDB51B00075AEC3 /* TaskSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskSummary.swift; sourceTree = "<group>"; };
 		5E82EEED2C68391C00548EC5 /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		5EA5C1332CC5FF2700CCE426 /* Launch Screen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = "Launch Screen.storyboard"; sourceTree = "<group>"; };
+		5EAEC5CF2CCDAD7A00BB11F8 /* TimerTaskListViewViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimerTaskListViewViewModel.swift; sourceTree = "<group>"; };
+		5EAEC5D12CCDAD8D00BB11F8 /* TaskTimer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaskTimer.swift; sourceTree = "<group>"; };
+		5EAEC5D52CCDADB600BB11F8 /* TaskTimerListView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaskTimerListView.swift; sourceTree = "<group>"; };
+		5EAEC5D72CCDAE9F00BB11F8 /* TaskTimerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskTimerView.swift; sourceTree = "<group>"; };
+		5EAEC5D92CCDAED900BB11F8 /* TaskTimerViewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskTimerViewViewModel.swift; sourceTree = "<group>"; };
+		5EAEC5DB2CCDB6D200BB11F8 /* NewTaskItemViewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTaskItemViewViewModel.swift; sourceTree = "<group>"; };
+		5EAEC5DD2CCDB7A100BB11F8 /* NewTaskItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTaskItemView.swift; sourceTree = "<group>"; };
 		5ED670202BB918CB0061210C /* MainView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainView.swift; sourceTree = "<group>"; };
 		5EDC5C1C2BB8DD7800363517 /* ToDoList.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ToDoList.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		5EDC5C1F2BB8DD7800363517 /* ToDoListApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToDoListApp.swift; sourceTree = "<group>"; };
@@ -117,18 +147,40 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		5E6E244C2CD9F6460075AEC3 /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				5E6E244D2CD9F66D0075AEC3 /* TimeFormatUtils.swift */,
+			);
+			path = Utils;
+			sourceTree = "<group>";
+		};
+		5E6E24532CDB425A0075AEC3 /* Enums */ = {
+			isa = PBXGroup;
+			children = (
+				5E6E24542CDB426E0075AEC3 /* SummaryRangeEnum.swift */,
+			);
+			path = Enums;
+			sourceTree = "<group>";
+		};
 		5E7E58872BB8EC150091A086 /* Views */ = {
 			isa = PBXGroup;
 			children = (
-				5ED670202BB918CB0061210C /* MainView.swift */,
+				5E3AC3662BB91CB3001C8876 /* HeaderView.swift */,
 				5E3AC3482BB919C6001C8876 /* LoginView.swift */,
-				5E3AC3682BB9239F001C8876 /* TLButton.swift */,
+				5ED670202BB918CB0061210C /* MainView.swift */,
 				5E3AC34A2BB919D5001C8876 /* NewItemView.swift */,
+				5EAEC5DD2CCDB7A100BB11F8 /* NewTaskItemView.swift */,
 				5E3AC34C2BB919E1001C8876 /* ProfileView.swift */,
 				5E3AC34E2BB919EE001C8876 /* RegisterView.swift */,
+				5E6E24562CDB4EBD0075AEC3 /* SummaryRangeView.swift */,
+				5E6E244F2CDB410F0075AEC3 /* SummaryView.swift */,
+				5EAEC5D52CCDADB600BB11F8 /* TaskTimerListView.swift */,
+				5EAEC5D72CCDAE9F00BB11F8 /* TaskTimerView.swift */,
+				5E6E244A2CD9F2AE0075AEC3 /* TimeSegmentListView.swift */,
+				5E3AC3682BB9239F001C8876 /* TLButton.swift */,
 				5E3AC3502BB919FC001C8876 /* ToDoListItemView.swift */,
 				5E3AC3522BB91A08001C8876 /* ToDoListView.swift */,
-				5E3AC3662BB91CB3001C8876 /* HeaderView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -136,11 +188,15 @@
 		5E7E58882BB8EC1A0091A086 /* ViewModels */ = {
 			isa = PBXGroup;
 			children = (
-				5E3AC3582BB91A86001C8876 /* MainViewViewModel.swift */,
 				5E3AC35A2BB91A8B001C8876 /* LoginViewViewModel.swift */,
+				5E3AC3582BB91A86001C8876 /* MainViewViewModel.swift */,
 				5E3AC35C2BB91A91001C8876 /* NewItemViewViewModel.swift */,
+				5EAEC5DB2CCDB6D200BB11F8 /* NewTaskItemViewViewModel.swift */,
 				5E3AC35E2BB91A99001C8876 /* ProfileViewViewModel.swift */,
 				5E3AC3602BB91A9F001C8876 /* RegisterViewViewModel.swift */,
+				5E6E24512CDB41BD0075AEC3 /* SummaryRangeViewViewModel.swift */,
+				5EAEC5D92CCDAED900BB11F8 /* TaskTimerViewViewModel.swift */,
+				5EAEC5CF2CCDAD7A00BB11F8 /* TimerTaskListViewViewModel.swift */,
 				5E3AC3622BB91AAA001C8876 /* ToDoListItemViewViewModel.swift */,
 				5E3AC3642BB91AB2001C8876 /* ToDoListViewViewModel.swift */,
 			);
@@ -150,6 +206,9 @@
 		5E7E58892BB8EC560091A086 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				5E6E24582CDB51B00075AEC3 /* TaskSummary.swift */,
+				5EAEC5D12CCDAD8D00BB11F8 /* TaskTimer.swift */,
+				5E6E24482CD9DCB60075AEC3 /* TimeSegment.swift */,
 				5E3AC3542BB91A30001C8876 /* ToDoListItem.swift */,
 				5E3AC3562BB91A37001C8876 /* User.swift */,
 			);
@@ -191,6 +250,8 @@
 		5EDC5C1E2BB8DD7800363517 /* ToDoList */ = {
 			isa = PBXGroup;
 			children = (
+				5E6E24532CDB425A0075AEC3 /* Enums */,
+				5E6E244C2CD9F6460075AEC3 /* Utils */,
 				5E7E588A2BB9161B0091A086 /* Other */,
 				5E7E58892BB8EC560091A086 /* Models */,
 				5E7E58882BB8EC1A0091A086 /* ViewModels */,
@@ -366,25 +427,40 @@
 			buildActionMask = 2147483647;
 			files = (
 				5E3AC34B2BB919D5001C8876 /* NewItemView.swift in Sources */,
+				5EAEC5DC2CCDB6D200BB11F8 /* NewTaskItemViewViewModel.swift in Sources */,
 				5E3AC3672BB91CB3001C8876 /* HeaderView.swift in Sources */,
 				5E3AC3512BB919FC001C8876 /* ToDoListItemView.swift in Sources */,
 				5E3AC3632BB91AAA001C8876 /* ToDoListItemViewViewModel.swift in Sources */,
 				5E3AC3592BB91A86001C8876 /* MainViewViewModel.swift in Sources */,
+				5E6E24492CD9DCB60075AEC3 /* TimeSegment.swift in Sources */,
+				5EAEC5D22CCDAD8D00BB11F8 /* TaskTimer.swift in Sources */,
+				5EAEC5DE2CCDB7A100BB11F8 /* NewTaskItemView.swift in Sources */,
 				5E3AC35D2BB91A91001C8876 /* NewItemViewViewModel.swift in Sources */,
+				5E6E24522CDB41BD0075AEC3 /* SummaryRangeViewViewModel.swift in Sources */,
+				5E6E24552CDB426E0075AEC3 /* SummaryRangeEnum.swift in Sources */,
 				5E3AC3532BB91A08001C8876 /* ToDoListView.swift in Sources */,
 				5E3AC3692BB9239F001C8876 /* TLButton.swift in Sources */,
 				5E3AC3612BB91A9F001C8876 /* RegisterViewViewModel.swift in Sources */,
 				5E3AC3492BB919C6001C8876 /* LoginView.swift in Sources */,
 				5E3AC34D2BB919E1001C8876 /* ProfileView.swift in Sources */,
+				5E6E24502CDB410F0075AEC3 /* SummaryView.swift in Sources */,
+				5EAEC5DA2CCDAED900BB11F8 /* TaskTimerViewViewModel.swift in Sources */,
 				5E3AC34F2BB919EE001C8876 /* RegisterView.swift in Sources */,
 				5E3AC35B2BB91A8B001C8876 /* LoginViewViewModel.swift in Sources */,
+				5EAEC5D02CCDAD7A00BB11F8 /* TimerTaskListViewViewModel.swift in Sources */,
 				5EDC5C202BB8DD7800363517 /* ToDoListApp.swift in Sources */,
 				5E3AC3652BB91AB2001C8876 /* ToDoListViewViewModel.swift in Sources */,
 				5E82EEEE2C68391C00548EC5 /* Extensions.swift in Sources */,
+				5EAEC5D82CCDAE9F00BB11F8 /* TaskTimerView.swift in Sources */,
 				5ED670212BB918CB0061210C /* MainView.swift in Sources */,
 				5E3AC35F2BB91A99001C8876 /* ProfileViewViewModel.swift in Sources */,
+				5E6E24592CDB51B00075AEC3 /* TaskSummary.swift in Sources */,
 				5E3AC3572BB91A37001C8876 /* User.swift in Sources */,
+				5E6E24572CDB4EBD0075AEC3 /* SummaryRangeView.swift in Sources */,
+				5E6E244B2CD9F2AE0075AEC3 /* TimeSegmentListView.swift in Sources */,
 				5E3AC3552BB91A30001C8876 /* ToDoListItem.swift in Sources */,
+				5EAEC5D62CCDADB600BB11F8 /* TaskTimerListView.swift in Sources */,
+				5E6E244E2CD9F66D0075AEC3 /* TimeFormatUtils.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ToDoList/Enums/SummaryRangeEnum.swift
+++ b/ToDoList/Enums/SummaryRangeEnum.swift
@@ -1,0 +1,15 @@
+//
+//  SummaryTypeEnum.swift
+//  ToDoList
+//
+//  Created by Jeffrey Zhou on 11/5/24.
+//
+
+import Foundation
+enum SummaryRangeEnum: String {
+    case day = "day"
+    case week = "week"
+    case month = "month"
+    case year = "year"
+    case allTime = "allTime"
+}

--- a/ToDoList/Models/TaskSummary.swift
+++ b/ToDoList/Models/TaskSummary.swift
@@ -1,0 +1,61 @@
+//
+//  TaskSummary.swift
+//  ToDoList
+//
+//  Created by Jeffrey Zhou on 11/5/24.
+//
+
+import Foundation
+
+struct TaskSummary : Codable, Equatable, Identifiable {
+    let id: String
+    let task: TaskTimer
+    let segments: [TaskTimeSegment]
+    let start: TimeInterval
+    let end: TimeInterval
+    
+    var totalDuration: TimeInterval {
+        var totalDuration = TimeInterval(0)
+        
+        for segment in segments {
+                    let duration = segment.end - segment.start
+                    totalDuration += duration
+                }
+        
+        return totalDuration
+    }
+    var averageDuration: TimeInterval {
+        return numSegments > 0 ? totalDuration / Double(numSegments) : 0
+    }
+    
+    var numSegments: Int {
+        return segments.count
+    }
+    var durationPercentage: Int {
+        let rangeDuration = end - start
+        guard rangeDuration > 0 else { return 0 }  // Avoid division by zero
+        
+        let percentage = (totalDuration / rangeDuration) * 100
+        return Int(percentage.rounded())
+    }
+    
+    mutating func addSegment(segment: TaskTimeSegment) {
+        // Create a copy of `segments` with the new segment added
+        var newSegments = segments
+        newSegments.append(segment)
+
+        // Calculate the new start and end times
+        let newStart = min(start, segment.start)
+        let newEnd = max(end, segment.end)
+
+        // Assign the modified copy back to self
+        self = TaskSummary(
+            id: self.id,
+            task: task,
+            segments: newSegments,
+            start: newStart,
+            end: newEnd
+        )
+    }
+    
+}

--- a/ToDoList/Models/TaskTimer.swift
+++ b/ToDoList/Models/TaskTimer.swift
@@ -1,0 +1,57 @@
+//
+//  TaskItem.swift
+//  ToDoList
+//
+//  Created by Jeffrey Zhou on 10/26/24.
+//
+
+import Foundation
+import FirebaseAuth
+import FirebaseFirestore
+
+struct TaskTimer : Codable, Identifiable, Equatable {
+    let id: String
+    let title: String
+    let createdDate: TimeInterval
+    
+    var isActive: Bool
+    var startTime: TimeInterval
+    var totalTimeSpent: TimeInterval
+    
+    mutating func start() {
+        isActive = true
+        startTime = Date().timeIntervalSince1970
+        save()
+    }
+    
+    mutating func stop() {
+//        guard startTime != nil && isActive else {
+//            print("Could not stop task - the task is not active or startTime is nil")
+//            return
+//        }
+//        let now = Date()
+//        let timeSpent = now.timeIntervalSince(startTime)
+//        totalTimeSpent = totalTimeSpent + timeSpent
+        print("About to stop active task:", self)
+        let timeSpent = Date().timeIntervalSince1970 - startTime
+        print("time spent", timeSpent, Date().timeIntervalSince1970, startTime)
+        totalTimeSpent = totalTimeSpent + timeSpent
+        isActive = false
+        startTime = 0.0
+        save()
+    }
+    
+    func save() {
+        // Get current user id
+        guard let uId = Auth.auth().currentUser?.uid else {
+            return
+        }
+        let db = Firestore.firestore()
+        
+        db.collection("users")
+            .document(uId)
+            .collection("tasks")
+            .document(id)
+            .setData(self.asDictionary())
+    }
+}

--- a/ToDoList/Models/TimeSegment.swift
+++ b/ToDoList/Models/TimeSegment.swift
@@ -1,0 +1,40 @@
+//
+//  TimeSegment.swift
+//  ToDoList
+//
+//  Created by Jeffrey Zhou on 11/4/24.
+//
+
+import Foundation
+import FirebaseAuth
+import FirebaseFirestore
+
+struct TaskTimeSegment : Codable, Identifiable, Equatable {
+    let id: String
+    let start: TimeInterval
+    let end: TimeInterval
+    let parentTaskId: String
+    
+    func save() {
+        print("save time segment", self.asDictionary())
+        // Get current user id
+        guard let uId = Auth.auth().currentUser?.uid else {
+            print("not logged in, skipping")
+            return
+        }
+        let db = Firestore.firestore()
+        
+        db.collection("users")
+            .document(uId)
+            .collection("segments")
+            .document(id)
+            .setData(self.asDictionary()) { error in
+                if let error = error {
+                    print("Error setting data: \(error.localizedDescription)")
+                } else {
+                    print("Data successfully written!")
+                }
+            }
+    }
+}
+

--- a/ToDoList/Other/Launch Screen.storyboard
+++ b/ToDoList/Other/Launch Screen.storyboard
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
-        <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -12,22 +12,23 @@
             <objects>
                 <viewController id="01J-lp-oVM" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="obG-Y5-kRd">
-                                <rect key="frame" x="0.0" y="626.5" width="375" height="20.5"/>
+                                <rect key="frame" x="0.0" y="832" width="393" height="0.0"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ToDoList" textAlignment="center" lineBreakMode="middleTruncation" baselineAdjustment="alignBaselines" minimumFontSize="18" translatesAutoresizingMaskIntoConstraints="NO" id="GJd-Yh-RWb">
-                                <rect key="frame" x="0.0" y="202" width="375" height="43"/>
+                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Task Timers" textAlignment="center" lineBreakMode="middleTruncation" baselineAdjustment="alignBaselines" minimumFontSize="18" translatesAutoresizingMaskIntoConstraints="NO" id="GJd-Yh-RWb">
+                                <rect key="frame" x="0.0" y="263.66666666666669" width="393" height="43"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="36"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="Bcu-3y-fUS"/>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="Bcu-3y-fUS" firstAttribute="centerX" secondItem="obG-Y5-kRd" secondAttribute="centerX" id="5cz-MP-9tL"/>
@@ -35,9 +36,8 @@
                             <constraint firstItem="obG-Y5-kRd" firstAttribute="leading" secondItem="Bcu-3y-fUS" secondAttribute="leading" constant="20" symbolic="YES" id="SfN-ll-jLj"/>
                             <constraint firstAttribute="bottom" secondItem="obG-Y5-kRd" secondAttribute="bottom" constant="20" id="Y44-ml-fuU"/>
                             <constraint firstItem="GJd-Yh-RWb" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="bottom" multiplier="1/3" constant="1" id="moa-c2-u7t"/>
-                            <constraint firstItem="GJd-Yh-RWb" firstAttribute="leading" secondItem="Bcu-3y-fUS" secondAttribute="leading" constant="20" symbolic="YES" id="x7j-FC-K8j"/>
+                            <constraint firstItem="GJd-Yh-RWb" firstAttribute="leading" secondItem="Bcu-3y-fUS" secondAttribute="leading" symbolic="YES" id="x7j-FC-K8j"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="Bcu-3y-fUS"/>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/ToDoList/Utils/TimeFormatUtils.swift
+++ b/ToDoList/Utils/TimeFormatUtils.swift
@@ -1,0 +1,64 @@
+//
+//  TimeFormatUtils.swift
+//  ToDoList
+//
+//  Created by Jeffrey Zhou on 11/4/24.
+//
+
+import Foundation
+
+public func formatTimeInterval(_ interval: TimeInterval) -> String {
+    let formatter = DateComponentsFormatter()
+    formatter.allowedUnits = [.hour, .minute, .second] // Specify the units you want
+    formatter.unitsStyle = .positional // Use positional style, e.g., "1:01:05"
+    formatter.zeroFormattingBehavior = .pad // Pads with zeros, e.g., "01:01:05"
+
+    return formatter.string(from: interval) ?? interval.formatted()
+}
+
+public func formatDuration(_ interval: TimeInterval) -> String {
+    // Handle durations less than a minute, showing seconds only
+    if interval < 60 {
+        return "\(Int(interval.rounded()))s"
+    }
+    
+    // Round to the nearest minute for any duration longer than 1 minute
+    let days = Int(interval) / 86400
+    let hours = (Int(interval) % 86400) / 3600
+    let minutes = (Int(interval) % 3600) / 60
+
+    // Build the output string based on non-zero components
+    var components: [String] = []
+    if days > 0 {
+        components.append("\(days)d")
+    }
+    if hours > 0 {
+        components.append("\(hours)h")
+    }
+    if minutes > 0 || components.isEmpty { // Ensure at least "0m" if all other units are zero
+        components.append("\(minutes)m")
+    }
+
+    return components.joined(separator: " ")
+}
+
+
+public func formatDate(_ interval: TimeInterval?) -> String {
+    if let interval = interval {
+        // Convert TimeInterval to Date
+        let date = Date(timeIntervalSince1970: interval)
+        
+        // Format the Date as "yyyy-MM-dd HH:mm:ss"
+        return date.formatted(.dateTime
+            .year(.defaultDigits)
+            .month(.twoDigits)
+            .day(.twoDigits)
+            .hour(.twoDigits(amPM: .omitted))
+            .minute(.twoDigits)
+            .second(.twoDigits))
+        
+    } else {
+        return "nil date"
+    }
+}
+

--- a/ToDoList/ViewModels/NewTaskItemViewViewModel.swift
+++ b/ToDoList/ViewModels/NewTaskItemViewViewModel.swift
@@ -1,0 +1,57 @@
+//
+//  NewTaskItemView.swift
+//  ToDoList
+//
+//  Created by Jeffrey Zhou on 10/26/24.
+//
+
+import Foundation
+import FirebaseAuth
+import FirebaseFirestore
+
+class NewTaskItemViewViewModel: ObservableObject {
+    @Published var title = ""
+    @Published var showAlert = false
+    
+    init() {}
+    
+    func save() {
+        guard canSave else {
+            return
+        }
+        
+        // Get current user id
+        guard let uId = Auth.auth().currentUser?.uid else {
+            return
+        }
+        
+        // Create model
+        let newId = UUID().uuidString
+        let newItem = TaskTimer(
+            id: newId,
+            title: title,
+            createdDate: Date().timeIntervalSince1970,
+            isActive: false,
+            startTime: Date().timeIntervalSince1970,
+            totalTimeSpent: 0
+        )
+        
+        // Save model to db
+        let db = Firestore.firestore()
+        
+        db.collection("users")
+            .document(uId)
+            .collection("tasks")
+            .document(newId)
+            .setData(newItem.asDictionary())
+        
+    }
+    
+    var canSave: Bool {
+        guard !title.trimmingCharacters(in: .whitespaces).isEmpty else {
+            return false
+        }
+        
+        return true
+    }
+}

--- a/ToDoList/ViewModels/RegisterViewViewModel.swift
+++ b/ToDoList/ViewModels/RegisterViewViewModel.swift
@@ -20,7 +20,7 @@ class RegisterViewViewModel: ObservableObject {
     func register() {
         print("Attempting to register user")
         guard validate() else {
-            print("invalid attempt!")
+            print("failed to validate input fields")
             return
         }
         
@@ -70,7 +70,7 @@ class RegisterViewViewModel: ObservableObject {
             return false
         }
         
-        guard password.count > 6 else {
+        guard password.count > 5 else {
             return false
         }
         

--- a/ToDoList/ViewModels/SummaryRangeViewViewModel.swift
+++ b/ToDoList/ViewModels/SummaryRangeViewViewModel.swift
@@ -1,0 +1,162 @@
+//
+//  SummaryViewViewModel.swift
+//  ToDoList
+//
+//  Created by Jeffrey Zhou on 11/5/24.
+//
+
+import Foundation
+
+import FirebaseAuth
+import FirebaseFirestore
+
+class SummaryRangeViewViewModel: ObservableObject {
+    @Published var taskSummaries: [TaskSummary] = []
+    @Published var taskSegments: [TaskTimeSegment] = []
+    @Published var tasks: [TaskTimer] = []
+    private var userId: String = ""
+    private var summaryRange: SummaryRangeEnum
+    private let db = Firestore.firestore()
+    
+    init(summaryRange: SummaryRangeEnum) {
+        self.summaryRange = summaryRange
+    }
+    
+    func getStartOfRange(now: TimeInterval, summaryRange: SummaryRangeEnum) -> TimeInterval? {
+        let oneDayInterval: TimeInterval = 24 * 60 * 60
+        let sevenDayInterval: TimeInterval = 7 * oneDayInterval
+        let thirtyDayInterval: TimeInterval = 30 * oneDayInterval
+        let threeSixtyFiveDayInterval: TimeInterval = 365 * oneDayInterval
+        switch summaryRange {
+            case SummaryRangeEnum.day:
+                return now - oneDayInterval
+            case SummaryRangeEnum.week:
+                return now - sevenDayInterval
+            case SummaryRangeEnum.month:
+                return now - thirtyDayInterval
+            case SummaryRangeEnum.year:
+                    return now - threeSixtyFiveDayInterval
+            case SummaryRangeEnum.allTime:
+                    return nil
+        }
+    }
+    
+    func getSummaries() async {
+        let tasks = await fetchTasks()
+        
+        let now = Date().timeIntervalSince1970
+        let start = getStartOfRange(now: now, summaryRange: summaryRange)
+        let end = now
+        let taskSegments = await fetchTaskTimerSegmentsInTimeRange(rangeStart: start, rangeEnd: end)
+        
+        // Step 1: Build a dictionary of tasks based on their `id`
+        var taskDictionary = [String: TaskTimer]()
+        for task in tasks {
+            taskDictionary[task.id] = task
+        }
+        
+        // Step 2: Build a dictionary of TaskSummary objects, keyed by `parentTaskId`
+        var summaryDictionary = [String: TaskSummary]()
+        
+        for segment in taskSegments {
+            if let task = taskDictionary[segment.parentTaskId] {
+                if var summary = summaryDictionary[segment.parentTaskId] {
+                    summary.addSegment(segment: segment)
+                    summaryDictionary[segment.parentTaskId] = summary
+                } else {
+                    summaryDictionary[segment.parentTaskId] = TaskSummary(
+                        id: UUID().uuidString,
+                        task: task,
+                        segments: [segment],
+                        start: start ?? TimeInterval(0),
+                        end: end
+                    )
+                }
+            }
+        }
+        
+        self.taskSummaries = Array(summaryDictionary.values).sorted(by: { (a: TaskSummary, b: TaskSummary) in
+            a.totalDuration < b.totalDuration
+        })
+    }
+    
+    func fetchTasks() async -> [TaskTimer] {
+        let query = db.collection("users")
+                .document(userId)
+                .collection("tasks")
+
+        do {
+            
+            let snapshot = try await query.getDocuments()
+            print("Performed query in Firestore, got tasks: \(snapshot.documents.count)")
+            
+            return snapshot.documents.compactMap { document in
+                try? document.data(as: TaskTimer.self)
+            }
+            
+        } catch let error as NSError {
+            // Handle Firestore-specific errors here
+            print("Firestore error: \(error.localizedDescription)")
+        } catch {
+            // Handle unexpected errors
+            print("Unexpected error: \(error.localizedDescription)")
+        }
+        
+        return []
+    }
+    
+    func fetchTaskTimerSegmentsInTimeRange(rangeStart: TimeInterval?, rangeEnd: TimeInterval) async -> [TaskTimeSegment] {
+        let db = Firestore.firestore()
+        
+        let ref = db.collection("users").document(userId).collection("segments")
+        var query: Query = ref
+        // Add optional start of query range
+        // rangeStart can be nil if we are searching for all segments before a certain time
+        if let rangeStart = rangeStart {
+            query = query.whereField("start", isGreaterThan: rangeStart)
+        }
+        // Add required end of query range
+        query = query.whereField("end", isLessThan: rangeEnd)
+        
+        do {
+            
+            let snapshot = try await query.getDocuments()
+            print("Performed query in Firestore, got this number of results: \(snapshot.documents.count)")
+            
+            return snapshot.documents.compactMap { document in
+                try? document.data(as: TaskTimeSegment.self)
+            }
+            
+        } catch let error as NSError {
+            // Handle Firestore-specific errors here
+            print("Firestore error: \(error.localizedDescription)")
+        } catch {
+            // Handle unexpected errors
+            print("Unexpected error: \(error.localizedDescription)")
+        }
+        
+        return []
+    }
+
+    
+    func getTaskSegments() async {
+        guard let userId = Auth.auth().currentUser?.uid else {
+            return
+        }
+        self.userId = userId
+        
+        let now = Date().timeIntervalSince1970
+        let start = getStartOfRange(now: now, summaryRange: summaryRange)
+        let end = now
+        
+        print("summary range: " + summaryRange.rawValue)
+        print("calculated start of range: " + formatDate(start) + " - " + (start?.description ?? "nil"))
+        print("calculated end of range: " + formatDate(end) + " - " + end.description)
+        
+        self.taskSegments = await fetchTaskTimerSegmentsInTimeRange(rangeStart: start, rangeEnd: end)
+        
+        print("number of task segments in range: " + self.taskSegments.count.description)
+    }
+    
+    
+}

--- a/ToDoList/ViewModels/TaskTimerViewViewModel.swift
+++ b/ToDoList/ViewModels/TaskTimerViewViewModel.swift
@@ -1,0 +1,19 @@
+//
+//  TaskItemViewViewModel().swift
+//  ToDoList
+//
+//  Created by Jeffrey Zhou on 10/26/24.
+//
+
+import Foundation
+import FirebaseAuth
+import FirebaseFirestore
+
+class TaskTimerViewViewModel: ObservableObject {
+    @Published var currentTimeSpent: TimeInterval = 0
+    var timer = Timer()
+    var startTime: Date? = nil
+    @Published var elapsedTimeSeconds: TimeInterval = 0
+    
+    init() {}
+}

--- a/ToDoList/ViewModels/TimerTaskListViewViewModel.swift
+++ b/ToDoList/ViewModels/TimerTaskListViewViewModel.swift
@@ -1,0 +1,135 @@
+//
+//  TimerTaskListViewViewModel.swift
+//  ToDoList
+//
+//  Created by Jeffrey Zhou on 10/26/24.
+//
+
+import Foundation
+import FirebaseAuth
+import FirebaseFirestore
+
+class TaskTimerListViewViewModel: ObservableObject {
+    @Published var showingNewTaskTimerView = false;
+    @Published var activeTaskId: String? = nil;
+    @Published var activeTask: TaskTimer? = nil;
+    @Published var activeTaskName: String? = nil;
+    @Published var elapsedTimeSeconds: TimeInterval = 0
+    
+    private var db: Firestore
+    var timer: Timer = Timer()
+    private let userId: String
+    
+    init(userId: String) {
+        self.userId = userId
+        self.db = Firestore.firestore()
+        Task {
+            do {
+                print("trying to query for snapshot of all active task timers")
+                let querySnapshot = try await self.db.collection("users").document(userId).collection("tasks").whereField("isActive", isEqualTo: true)
+                    .getDocuments()
+
+                let activeTaskTimers: [TaskTimer] = try querySnapshot.documents.compactMap { document in
+                        try document.data(as: TaskTimer.self)  // Decode document data as TaskTimer
+                    }
+                
+                if activeTaskTimers.count > 1 {
+                    print("Error: More than one active timer found in db")
+                    return
+                }
+                
+                if let activeTask = activeTaskTimers.first {
+                    
+                    self.activeTaskId = activeTask.id
+                    self.activeTaskName = activeTask.title
+                    self.elapsedTimeSeconds = Date().timeIntervalSince1970 - activeTask.startTime
+                    self.startTimer()
+
+                } else {
+                    print("No documents found in querySnapshot.")
+                }
+                
+                print("Found all docs with active status: " + querySnapshot.documents.count.description)
+            } catch {
+                print("Error getting documents: \(error)")
+            }
+        }
+    }
+    
+    func delete(id: String) {
+        db.collection("users")
+            .document(userId)
+            .collection("tasks")
+            .document(id)
+            .delete()
+    }
+    
+    func fetchTaskFromDatabase(id: String, completion: @escaping (TaskTimer?) -> Void) {
+        let docRef = db.collection("users")
+            .document(userId)
+            .collection("tasks")
+            .document(id)
+
+        docRef.getDocument(as: TaskTimer.self) { result in
+            switch result {
+            case .success(let task):
+              // A Book value was successfully initialized from the DocumentSnapshot.
+                completion(task)
+            case .failure(let error):
+                print("Error decoding document: \(error.localizedDescription)")
+                completion(nil)
+            }
+        }
+    }
+
+    
+    func switchTask(newTask: TaskTimer) {
+        // Determine whether the start a new task based on if the newly requested task
+        // is equal to the currently active task or not
+        let startNewTask = (newTask.id != activeTask?.id)
+        print("Switching task ", newTask.title)
+        print("Start new task bool: " + startNewTask.description)
+        
+        if var activeTask = activeTask {
+            print("Stopping: \(activeTask.title)")
+            let newTimeSegment = TaskTimeSegment(
+                id: UUID().uuidString,
+                start: activeTask.startTime,
+                end: Date().timeIntervalSince1970,
+                parentTaskId: activeTask.id
+            )
+            activeTask.stop()
+            newTimeSegment.save()
+            resetTimer()
+            
+            self.activeTask = nil
+            self.activeTaskId = nil
+            self.activeTaskName = "none"
+        }
+        
+        if startNewTask {
+            var newTaskCopy = newTask
+            newTaskCopy.start()
+            startTimer()
+            
+            activeTask = newTaskCopy
+            activeTaskId = newTaskCopy.id
+            activeTaskName = newTaskCopy.title
+        }
+    }
+    
+    func startTimer() {
+        timer.invalidate()
+        print("starting timer")
+        timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true, block: {(timer) in
+            self.elapsedTimeSeconds += 1
+            print("tick")
+        })
+    }
+    
+    func resetTimer() {
+        timer.invalidate()
+        elapsedTimeSeconds = 0
+    }
+
+}

--- a/ToDoList/Views/MainView.swift
+++ b/ToDoList/Views/MainView.swift
@@ -20,9 +20,13 @@ struct MainView: View {
     @ViewBuilder
     var accountView: some View {
         TabView {
-            ToDoListView(userId: viewModel.currentUserId)
+            TaskTimerListView(userId: viewModel.currentUserId)
                 .tabItem{
-                    Label("Home", systemImage: "house")
+                    Label("Task Timers", systemImage: "house")
+                }
+            SummaryView()
+                .tabItem{
+                    Label("Summary", systemImage: "house")
                 }
             ProfileView()
                 .tabItem{

--- a/ToDoList/Views/NewTaskItemView.swift
+++ b/ToDoList/Views/NewTaskItemView.swift
@@ -1,0 +1,53 @@
+//
+//  NewTaskItemView.swift
+//  ToDoList
+//
+//  Created by Jeffrey Zhou on 10/26/24.
+//
+
+import SwiftUI
+
+struct NewTaskItemView: View {
+    @StateObject var viewModel = NewTaskItemViewViewModel()
+    @Binding var visible: Bool
+    
+    var body: some View {
+        VStack {
+            Text("New Task")
+                .font(.system(size:32))
+                .bold()
+                .padding(.top, 100)
+            
+            Form {
+                // Title
+                TextField("Title", text: $viewModel.title)
+                
+                // Button
+                TLButton(title: "Save",
+                         background: .pink) {
+                    if viewModel.canSave {
+                        viewModel.save()
+                        visible = false
+                    } else {
+                        viewModel.showAlert = true
+                    }
+                                        
+                }
+                .padding()
+            }
+            .alert(isPresented: $viewModel.showAlert) {
+                Alert(title: Text("Error"), message: Text("Please fill in all fields and select due date that is today or newer."))
+            }
+        }
+    }
+}
+
+struct NewTaskItemView_Previews: PreviewProvider {
+    static var previews: some View {
+        NewTaskItemView(visible: Binding(get: {
+            return true
+        }, set: {_ in
+            
+        }))
+    }
+}

--- a/ToDoList/Views/SummaryRangeView.swift
+++ b/ToDoList/Views/SummaryRangeView.swift
@@ -1,0 +1,35 @@
+//
+//  SummaryRangeView.swift
+//  ToDoList
+//
+//  Created by Jeffrey Zhou on 11/5/24.
+//
+
+import Foundation
+import SwiftUI
+import FirebaseAuth
+import FirebaseFirestore
+
+struct SummaryRangeView: View {
+    @StateObject private var viewModel: SummaryRangeViewViewModel
+    @State var selected = 1
+    
+    init(summaryRange: SummaryRangeEnum) {
+        self._viewModel = StateObject(wrappedValue: SummaryRangeViewViewModel(summaryRange: summaryRange))
+    }
+    
+    var body: some View {
+        List(viewModel.taskSummaries) { summary in
+            VStack(alignment: .leading) {
+                Text(summary.task.title)
+                Text("Duration: " + formatDuration(summary.totalDuration))
+            }
+        }
+        .onAppear {
+            Task {
+                await viewModel.getTaskSegments()
+                await viewModel.getSummaries()
+            }
+        }
+    }
+}

--- a/ToDoList/Views/SummaryView.swift
+++ b/ToDoList/Views/SummaryView.swift
@@ -1,0 +1,52 @@
+//
+//  SummaryView.swift
+//  ToDoList
+//
+//  Created by Jeffrey Zhou on 11/5/24.
+//
+
+import Foundation
+
+import SwiftUI
+import FirebaseFirestoreSwift
+
+struct SummaryView: View {
+    @State var selected: String = "day"
+    
+    init() {}
+    
+    var body: some View {
+        NavigationView {
+            VStack {
+                Picker(selection: $selected, label: Text("Picker"), content: {
+                    Text("1-day").tag("day")
+                    Text("7-day").tag("week")
+                    Text("30-day").tag("month")
+                    Text("All Time").tag("allTime")
+                })
+                .padding()
+                .pickerStyle(SegmentedPickerStyle())
+                
+                if (selected == "day") {
+                    SummaryRangeView(summaryRange: SummaryRangeEnum.day)
+                } else if (selected == "week") {
+                    SummaryRangeView(summaryRange: SummaryRangeEnum.week)
+                } else if (selected == "month") {
+                    SummaryRangeView(summaryRange: SummaryRangeEnum.month)
+                } else if (selected == "year") {
+                    SummaryRangeView(summaryRange: SummaryRangeEnum.year)
+                } else if (selected == "allTime") {
+                    SummaryRangeView(summaryRange: SummaryRangeEnum.allTime)
+                }
+            }
+            
+        }
+        .navigationTitle("Summary View")
+    }
+}
+
+struct SummaryView_Previews: PreviewProvider {
+    static var previews: some View {
+        SummaryView()
+    }
+}

--- a/ToDoList/Views/TaskTimerListView.swift
+++ b/ToDoList/Views/TaskTimerListView.swift
@@ -1,0 +1,70 @@
+//
+//  AllTimerTasksView.swift
+//  ToDoList
+//
+//  Created by Jeffrey Zhou on 10/26/24.
+//
+
+import SwiftUI
+import Foundation
+import FirebaseFirestoreSwift
+
+struct TaskTimerListView: View {
+    @StateObject var viewModel: TaskTimerListViewViewModel
+    @FirestoreQuery var tasks: [TaskTimer]
+
+    private let userId: String
+    
+    init(userId: String) {
+        self.userId = userId
+        self._tasks = FirestoreQuery(
+            collectionPath: "users/\(userId)/tasks"
+        )
+        
+        // Initialize _viewModel with a placeholder first
+        self._viewModel = StateObject(wrappedValue: TaskTimerListViewViewModel(userId: userId))
+    }
+    
+    var body: some View {
+        NavigationView {
+            VStack {
+                List(self.tasks) { task in
+                    TaskTimerView(
+                                switchTaskCallback: { task in
+                                    viewModel.switchTask(newTask: task)
+                                    // Define what should happen when switchTask is called
+                                    print("Switch task function called")
+                                },
+                                activeTask: $viewModel.activeTask,
+                                elapsedTimeSeconds: $viewModel.elapsedTimeSeconds,
+                                task: task // Provide an instance of TaskTimer
+                            )
+                        .swipeActions {
+                            Button("Delete") {
+                               viewModel.delete(id: task.id)
+                            }
+                            .tint(.red)
+                        }
+                }
+
+            }
+            .navigationTitle("Tasks")
+            .toolbar {
+                Button {
+                    viewModel.showingNewTaskTimerView = true
+                } label : {
+                    Image(systemName: "plus")
+                }
+            }
+            .sheet(isPresented: $viewModel.showingNewTaskTimerView) {
+                NewTaskItemView(visible: $viewModel.showingNewTaskTimerView)
+            }
+        }
+    }
+}
+
+struct TimerTaskListView_Previews: PreviewProvider {
+    static var previews: some View {
+        TaskTimerListView(userId: "Ob1mIAlkElam46mu24bllKBhsvo2")
+    }
+}

--- a/ToDoList/Views/TaskTimerView.swift
+++ b/ToDoList/Views/TaskTimerView.swift
@@ -1,0 +1,59 @@
+//
+//  TaskItemView.swift
+//  ToDoList
+//
+//  Created by Jeffrey Zhou on 10/26/24.
+//
+
+import Foundation
+import SwiftUI
+
+struct TaskTimerView: View {
+    let switchTaskCallback: (TaskTimer) -> Void
+    @Binding var activeTask: TaskTimer?
+    @Binding var elapsedTimeSeconds: TimeInterval
+    @StateObject var viewModel = TaskTimerViewViewModel()
+    let task: TaskTimer
+    
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading) {
+                Text(task.title)
+                    .font(.body)
+                    .bold()
+                Text("Total time: " + formatTimeInterval(task.totalTimeSpent))
+                if task.id == activeTask?.id {
+                    Text("Task has started: " + formatTimeInterval(elapsedTimeSeconds))
+                }
+            }
+            
+            Spacer()
+            
+            Button {
+                switchTaskCallback(task)
+            } label : {
+                Image(systemName: task.isActive ? "checkmark.circle.fill" : "circle")
+                    .foregroundColor(Color.blue)
+            }
+        }
+    }
+}
+
+#Preview {
+    TaskTimerView(
+        switchTaskCallback: {task in
+            // Define what should happen when switchTask is called
+            print("Switch task function called with task: \(task)")
+        },
+        activeTask: .constant(nil), // Use .constant for Binding in previews
+        elapsedTimeSeconds: .constant(0),
+        task: TaskTimer(
+            id: "123",
+            title: "Get milk",
+            createdDate: Date().timeIntervalSince1970,
+            isActive: true,
+            startTime: 0,
+            totalTimeSpent: 100
+        )
+    )
+}

--- a/ToDoList/Views/TimeSegmentListView.swift
+++ b/ToDoList/Views/TimeSegmentListView.swift
@@ -1,0 +1,49 @@
+//
+//  TimeSegmentListView.swift
+//  ToDoList
+//
+//  Created by Jeffrey Zhou on 11/4/24.
+//
+
+import Foundation
+
+import SwiftUI
+import FirebaseFirestoreSwift
+
+struct TimeSegmentListView: View {
+//    @StateObject var viewModel: TaskTimerListViewViewModel
+    @FirestoreQuery var timeSegments: [TaskTimeSegment]
+
+    private let userId: String
+    
+    init(userId: String) {
+        self.userId = userId
+        self._timeSegments = FirestoreQuery(
+            collectionPath: "users/\(userId)/segments"
+        )
+        
+        // Initialize _viewModel with a placeholder first
+//        self._viewModel = StateObject(wrappedValue: TimeSegmentListViewViewModel(userId: userId))
+    }
+    
+    var body: some View {
+        NavigationView {
+            VStack {
+                List(self.timeSegments) { timeSegment in
+                    VStack {
+                        Text(timeSegment.parentTaskId)
+                        Text("start: " + formatDate(timeSegment.start))
+                        Text("end: " + formatDate(timeSegment.end))
+                    }
+                }
+            }
+            .navigationTitle("Time Segments")
+        }
+    }
+}
+
+//struct TimerTaskListView_Previews: PreviewProvider {
+//    static var previews: some View {
+//        TaskTimerListView(userId: "Ob1mIAlkElam46mu24bllKBhsvo2")
+//    }
+//}


### PR DESCRIPTION
# Description
This PR adds the basic MVP functionality for a time tracking app, which includes:
- The ability to create new "task timers" with a title
- The ability to start and stop timers for each task, which create "task segments" on the backend
- The ability to see historic time spent in certain ranges (day, week, month, all-time)
- A simple profile view, which includes the email and date of joining

# Database
Currently Firestore is the main database. ([link to console](https://console.firebase.google.com/project/todolist-261c8/firestore/databases/-default-/data))

# Screenshots

### Create Task Timer
<img width="300" alt="image" src="https://github.com/user-attachments/assets/0b945c33-c017-43ee-b49b-084504c8ce01" />

### Task Timer List
<img width="300" alt="image" src="https://github.com/user-attachments/assets/95f998b9-1db5-43ba-8f3b-024196b21997" />

### Summary View
<img width="300" alt="image" src="https://github.com/user-attachments/assets/45232ddb-dfc6-4531-bc42-6df24f570174" />

### Profile View
<img width="300" alt="image" src="https://github.com/user-attachments/assets/90feb16a-47b5-413b-8d40-0a8b244dcf68" />
